### PR TITLE
Remove method_missing dependency of ATTRIBUTES

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,8 +1,8 @@
 class Repository
   #
-  # attributes
+  # attributes to list automatically
   #
-  ATTRIBUTES = %i(name description created_at pushed_at homepage
+  ATTRIBUTES = %i(description created_at pushed_at homepage
                   language stargazers_count forks_count open_issues_count
                   network_count subscribers_count watchers_count)
 
@@ -24,7 +24,7 @@ class Repository
   private
 
   def method_missing(method_sym, *_arguments, &_block)
-    return repository[method_sym] if ATTRIBUTES.include? method_sym
+    return repository[method_sym] if repository.respond_to? method_sym
 
     super
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -7,6 +7,9 @@ class Repository
 
   attr_accessor :repository
 
+  extend Forwardable
+  def_delegators :@repository, :name, :owner, *ATTRIBUTES
+
   #
   # methods
   #
@@ -18,13 +21,5 @@ class Repository
     new(repository: Octokit.repository(owner: owner, name: name))
   rescue Octokit::NotFound => e
     nil
-  end
-
-  private
-
-  def method_missing(method_sym, *_arguments, &_block)
-    return repository[method_sym] if repository.respond_to? method_sym
-
-    super
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -2,9 +2,8 @@ class Repository
   #
   # attributes to list automatically
   #
-  ATTRIBUTES = %i(description created_at pushed_at homepage
-                  language stargazers_count forks_count open_issues_count
-                  network_count subscribers_count watchers_count)
+  ATTRIBUTES = %i(description homepage language created_at pushed_at
+                  stargazers_count subscribers_count forks_count open_issues_count)
 
   attr_accessor :repository
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe Repository do
   let(:repository) do
     OpenStruct.new(
+      name: 'name',
       description: 'description',
       created_at: 1.day.ago,
       pushed_at: Time.now,

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Repository do
       stargazers_count: 1,
       forks_count: 1,
       open_issues_count: 1,
-      network_count: 1,
-      subscribers_count: 1,
-      watchers_count: 1)
+      subscribers_count: 1)
   end
   subject { described_class.new(repository: repository) }
 
@@ -30,9 +28,7 @@ RSpec.describe Repository do
   it { expect(subject.stargazers_count).to eq repository.stargazers_count }
   it { expect(subject.forks_count).to eq repository.forks_count }
   it { expect(subject.open_issues_count).to eq repository.open_issues_count }
-  it { expect(subject.network_count).to eq repository.network_count }
   it { expect(subject.subscribers_count).to eq repository.subscribers_count }
-  it { expect(subject.watchers_count).to eq repository.watchers_count }
 
   describe '.find_by' do
     it 'when exists repository' do


### PR DESCRIPTION
The attribute **name** was removed from ATTRIBUTES, cause it was duplicated in the list and in the header.
ATTRIBUTES should contain only the ones will be listed automatically. 